### PR TITLE
HTTP::Handler is not a class anymore

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,4 @@ development_dependencies:
 authors:
   - Serdar Dogruyol <dogruyolserdar@gmail.com>
 
-
-crystal: 0.20.0
-
 license: MIT

--- a/src/kemal-basic-auth.cr
+++ b/src/kemal-basic-auth.cr
@@ -6,7 +6,8 @@ require "kemal"
 #
 # basic_auth "username", "password"
 #
-class HTTPBasicAuth < HTTP::Handler
+class HTTPBasicAuth
+  include HTTP::Handler
   BASIC                 = "Basic"
   AUTH                  = "Authorization"
   AUTH_MESSAGE          = "Could not verify your access level for that URL.\nYou have to login with proper credentials"


### PR DESCRIPTION
Hi sdogruyol !

- Update for current crystal about `HTTP::Handler`
- Removed `crystal:` part from `shard.yml` ( consistent with `kemal` library)

Thanks for nice framework!