### PR TITLE
Accept multiple users for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,20 @@ dependencies:
 require "kemal-basic-auth"
 
 basic_auth "username", "password"
+# basic_auth {"username1" => "password1", "username2" => "password2"}
 ```
 
+### `kemal_authorized_username`
+
+`HTTP::Server::Context#kemal_authorized_username?` is set when the user is authorized.
+
+```crystal
+basic_auth {"guest" => "123", "admin" => "xyz"}
+
+get "/" do |env|
+  "Hi, %s!" % env.kemal_authorized_username?
+end
+```
 
 ## Contributing
 

--- a/spec/credentials_spec.cr
+++ b/spec/credentials_spec.cr
@@ -1,0 +1,17 @@
+require "./spec_helper"
+
+describe "HTTPBasicAuth::Credentials" do
+  it "#authorize?" do
+    entries = {
+      "serdar"   => "123",
+      "dogruyol" => "abc",
+    }
+    crendentials = HTTPBasicAuth::Credentials.new(entries)
+
+    crendentials.authorize?("serdar"  , "123").should eq("serdar")
+    crendentials.authorize?("serdar"  , "xxx").should eq(nil)
+    crendentials.authorize?("dogruyol", "abc").should eq("dogruyol")
+    crendentials.authorize?("dogruyol", "xxx").should eq(nil)
+    crendentials.authorize?("foo"     , "bar").should eq(nil)
+  end
+end

--- a/spec/kemal-basic-auth_spec.cr
+++ b/spec/kemal-basic-auth_spec.cr
@@ -9,9 +9,10 @@ describe "HTTPBasicAuth" do
       headers: HTTP::Headers{"Authorization" => "Basic c2VyZGFyOjEyMw=="},
     )
 
-    io_with_context = create_request_and_return_io(auth_handler, request)
-    client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
+    io, context = create_request_and_return_io_and_context(auth_handler, request)
+    client_response = HTTP::Client::Response.from_io(io, decompress: false)
     client_response.status_code.should eq 404
+    context.kemal_authorized_username?.should eq("serdar")
   end
 
   it "returns 401 with incorrect credentials" do
@@ -21,9 +22,10 @@ describe "HTTPBasicAuth" do
       "/",
       headers: HTTP::Headers{"Authorization" => "NotBasic"},
     )
-    io_with_context = create_request_and_return_io(auth_handler, request)
-    client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
+    io, context = create_request_and_return_io_and_context(auth_handler, request)
+    client_response = HTTP::Client::Response.from_io(io, decompress: false)
     client_response.status_code.should eq 401
+    context.kemal_authorized_username?.should eq(nil)
   end
 
   it "adds HTTPBasicAuthHandler" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,12 +1,12 @@
 require "spec"
 require "../src/kemal-basic-auth"
 
-def create_request_and_return_io(handler, request)
+def create_request_and_return_io_and_context(handler, request)
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
   handler.call(context)
   response.close
   io.rewind
-  io
+  {io, context}
 end

--- a/src/kemal-basic-auth.cr
+++ b/src/kemal-basic-auth.cr
@@ -1,10 +1,17 @@
 require "base64"
 require "kemal"
+require "./kemal-basic-auth/*"
 
 # This middleware adds HTTP Basic Auth support to your application.
 # Returns 401 "Unauthorized" with wrong credentials.
 #
+# ```crystal
 # basic_auth "username", "password"
+# # basic_auth {"username1" => "password2", "username2" => "password2"}
+# ```
+#
+# `HTTP::Server::Context#authorized_username` is set when the user is
+# authorized.
 #
 class HTTPBasicAuth
   include HTTP::Handler
@@ -13,14 +20,26 @@ class HTTPBasicAuth
   AUTH_MESSAGE          = "Could not verify your access level for that URL.\nYou have to login with proper credentials"
   HEADER_LOGIN_REQUIRED = "Basic realm=\"Login Required\""
 
-  def initialize(@username : String?, @password : String?)
+  def initialize(@credentials : Credentials)
   end
 
+  # backward compatibility
+  def initialize(username : String, password : String)
+    initialize({ username => password })
+  end
+
+  def initialize(hash : Hash(String, String))
+    initialize(Credentials.new(hash))
+  end
+  
   def call(context)
     if context.request.headers[AUTH]?
       if value = context.request.headers[AUTH]
         if value.size > 0 && value.starts_with?(BASIC)
-          return call_next(context) if authorized?(value)
+          if username = authorize?(value)
+            context.kemal_authorized_username = username
+            return call_next(context)
+          end
         end
       end
     end
@@ -30,13 +49,17 @@ class HTTPBasicAuth
     context.response.print AUTH_MESSAGE
   end
 
-  def authorized?(value)
+  def authorize?(value) : String?
     username, password = Base64.decode_string(value[BASIC.size + 1..-1]).split(":")
-    @username == username && @password == password
+    @credentials.authorize?(username, password)
   end
 end
 
 # Helper to easily add HTTP Basic Auth support.
 def basic_auth(username, password)
   add_handler HTTPBasicAuth.new(username, password)
+end
+
+def basic_auth(crendentials : Hash(String, String))
+  add_handler HTTPBasicAuth.new(crendentials)
 end

--- a/src/kemal-basic-auth/credentials.cr
+++ b/src/kemal-basic-auth/credentials.cr
@@ -1,0 +1,14 @@
+class HTTPBasicAuth
+  class Credentials
+    def initialize(@entries : Hash(String, String) = Hash(String, String).new)
+    end
+
+    def authorize?(username : String, password : String) : String?
+      if @entries[username]? == password
+        username
+      else
+        nil
+      end
+    end
+  end
+end

--- a/src/kemal-basic-auth/ext.cr
+++ b/src/kemal-basic-auth/ext.cr
@@ -1,0 +1,3 @@
+class HTTP::Server::Context
+  property? kemal_authorized_username : String?
+end


### PR DESCRIPTION
Hi @sdogruyol !
I am facing a usecase where multiple users should be authenticated and identified.

```
basic_auth {"guest" => "123", "admin" => "xyz"}

get "/" do |env|
  "Hi, %s!" % env.kemal_authorized_username?
end
```

Thanks.