### PR TITLE
Credentials now accumulates entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ get "/" do |env|
 end
 ```
 
+### accumulated entries
+
+When `basic_auth` is called in several times, the credentials are accumulated and shared by all pages.
+
+```crystal
+basic_auth "user1", "123"
+get "/members" do |env|
+  "restricted page" # both `user1` and `guest` can see this page.
+end
+
+basic_auth "guest", "temp"
+get "/trial" do |env|
+  "restricted page" # both `user1` and `guest` can see this page.
+end
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/kemalcr/kemal-basic-auth/fork )

--- a/spec/credentials_spec.cr
+++ b/spec/credentials_spec.cr
@@ -6,12 +6,35 @@ describe "HTTPBasicAuth::Credentials" do
       "serdar"   => "123",
       "dogruyol" => "abc",
     }
-    crendentials = HTTPBasicAuth::Credentials.new(entries)
+    credentials = HTTPBasicAuth::Credentials.new(entries)
 
-    crendentials.authorize?("serdar"  , "123").should eq("serdar")
-    crendentials.authorize?("serdar"  , "xxx").should eq(nil)
-    crendentials.authorize?("dogruyol", "abc").should eq("dogruyol")
-    crendentials.authorize?("dogruyol", "xxx").should eq(nil)
-    crendentials.authorize?("foo"     , "bar").should eq(nil)
+    credentials.authorize?("serdar"  , "123").should eq("serdar")
+    credentials.authorize?("serdar"  , "xxx").should eq(nil)
+    credentials.authorize?("dogruyol", "abc").should eq("dogruyol")
+    credentials.authorize?("dogruyol", "xxx").should eq(nil)
+    credentials.authorize?("foo"     , "bar").should eq(nil)
+  end
+
+  describe "#update" do
+    credentials = HTTPBasicAuth::Credentials.new
+
+    it "(String, String) adds a new entry" do
+      credentials.authorize?("serdar", "123").should eq(nil)
+      credentials.update("serdar", "123")
+      credentials.authorize?("serdar", "123").should eq("serdar")
+      credentials.authorize?("serdar", "xxx").should eq(nil)
+    end
+
+    it "(Hash) adds new entries" do
+      credentials.update({"a" => "1", "b" => "2"})
+      credentials.authorize?("a", "1").should eq("a")
+      credentials.authorize?("a", "x").should eq(nil)
+      credentials.authorize?("b", "2").should eq("b")
+      credentials.authorize?("c", "3").should eq(nil)
+    end
+
+    it "preserves accumulated entries" do
+      credentials.authorize?("serdar", "123").should eq("serdar")
+    end
   end
 end

--- a/spec/kemal-basic-auth_spec.cr
+++ b/spec/kemal-basic-auth_spec.cr
@@ -28,8 +28,23 @@ describe "HTTPBasicAuth" do
     context.kemal_authorized_username?.should eq(nil)
   end
 
-  it "adds HTTPBasicAuthHandler" do
+  it "adds HTTPBasicAuthHandler at most once" do
     basic_auth "serdar", "123"
     Kemal.config.handlers.size.should eq 6
+
+    basic_auth "dogruyol", "abc"
+    Kemal.config.handlers.size.should eq 6
+  end
+
+  describe ".runtime" do
+    it "returns singleton instance" do
+      HTTPBasicAuth.runtime.should be_a(HTTPBasicAuth)
+    end
+
+    it "is affected by `basic_auth`" do
+      HTTPBasicAuth.runtime.authorize?("a", "1").should eq(nil)
+      basic_auth "a", "1"
+      HTTPBasicAuth.runtime.authorize?("a", "1").should eq("a")
+    end
   end
 end

--- a/src/kemal-basic-auth/credentials.cr
+++ b/src/kemal-basic-auth/credentials.cr
@@ -1,6 +1,8 @@
-class HTTPBasicAuth
+class HTTPBasicAuth 
   class Credentials
-    def initialize(@entries : Hash(String, String) = Hash(String, String).new)
+    alias Entries = Hash(String, String)
+
+    def initialize(@entries : Entries = Entries.new)
     end
 
     def authorize?(username : String, password : String) : String?
@@ -9,6 +11,14 @@ class HTTPBasicAuth
       else
         nil
       end
+    end
+
+    def update(username : String, password : String)
+      @entries[username] = password
+    end
+
+    def update(other : Entries)
+      @entries.merge!(other)
     end
   end
 end


### PR DESCRIPTION
Hi @sdogruyol !
I'm now heavily using `basic_auth` and it would be nice if we can call it in several times for independency of pages. This PR enables it. 

```crystal
# foo.cr
basic_auth "user1", "123"
get "/foo" do
  ...

# bar.cr
basic_auth "staff", "456"
get "/bar" do
  ...
```

#### Impact

- Added `HTTPBasicAuth.runtime` method that keeps singleton instance object. This looks like well known `INSTANCE` technic except instantiating it lazily due to add_handler stuff.
- `basic_auth` is now a simple proxy to the `runtime`. Thus, we can accumulate entries.

 I'm glad if you like this! I'll create a new PR soon for a limited page authorization. :smile:

Thanks.