### PR TITLE
Prevent timing attacks

### DIFF
--- a/spec/credentials_spec.cr
+++ b/spec/credentials_spec.cr
@@ -3,15 +3,17 @@ require "./spec_helper"
 describe "HTTPBasicAuth::Credentials" do
   it "#authorize?" do
     entries = {
-      "serdar"   => "123",
+      "serdar"   => "12345",
       "dogruyol" => "abc",
     }
     crendentials = HTTPBasicAuth::Credentials.new(entries)
 
-    crendentials.authorize?("serdar"  , "123").should eq("serdar")
-    crendentials.authorize?("serdar"  , "xxx").should eq(nil)
+    crendentials.authorize?("serdar", "12345").should eq("serdar")
+    crendentials.authorize?("serdar", "xxx").should eq(nil)
     crendentials.authorize?("dogruyol", "abc").should eq("dogruyol")
     crendentials.authorize?("dogruyol", "xxx").should eq(nil)
-    crendentials.authorize?("foo"     , "bar").should eq(nil)
+    crendentials.authorize?("foo", "bar").should eq(nil)
+    crendentials.authorize?("foo", "").should eq(nil)
+    crendentials.authorize?("", "bar").should eq(nil)
   end
 end

--- a/src/kemal-basic-auth/credentials.cr
+++ b/src/kemal-basic-auth/credentials.cr
@@ -1,14 +1,31 @@
+require "crypto/subtle"
+
 class HTTPBasicAuth
   class Credentials
     def initialize(@entries : Hash(String, String) = Hash(String, String).new)
     end
 
-    def authorize?(username : String, password : String) : String?
-      if @entries[username]? == password
+    def authorize?(username : String, given_password : String) : String?
+      test_password = find_password(username, given_password)
+      if Crypto::Subtle.constant_time_compare(test_password, given_password)
         username
       else
         nil
       end
+    end
+
+    private def find_password(username, given_password)
+      # return a password that cannot possibly be correct if the username is wrong
+      pw = "not #{given_password}"
+
+      # iterate through each possibility to not leak info about valid usernames
+      @entries.each do |(user, password)|
+        if Crypto::Subtle.constant_time_compare(user, username)
+          pw = password
+        end
+      end
+
+      pw
     end
   end
 end


### PR DESCRIPTION
Before the password could be timing attacked due to the normal `String#==` instead of a constant time comparison. This patch makes use of `Crypto::Subtle` to avoid this.

The username is a little tricker since it was going through the hash table, but the existence of a valid username even if the password was wrong would have a difference in time. This patch iterates through each username regardless of if it's found or not to avoid this.